### PR TITLE
New `generateID` method and short ID generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Then pass the generator as part of the `configure` method:
 StableID.configure(idGenerator: MyCustomIDGenerator())
 ```
 
+**Built-in generators**
+- `StableID.StandardGenerator`: Standard UUIDs
+- `StableID.ShortIDGenerator`: 8-character alphanumeric IDs
+
 ## 📚 Examples
 
 _Coming soon_

--- a/Sources/StableID/Generators/IDGenerator.swift
+++ b/Sources/StableID/Generators/IDGenerator.swift
@@ -19,4 +19,16 @@ extension StableID {
             return UUID().uuidString
         }
     }
+
+    public class ShortIDGenerator: IDGenerator {
+        public init() { }
+
+        public func generateID() -> String {
+            let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+            return String((0..<8).compactMap { _ in
+                letters.randomElement()
+            })
+        }
+    }
 }

--- a/Sources/StableID/StableID.swift
+++ b/Sources/StableID/StableID.swift
@@ -87,12 +87,21 @@ public class StableID {
                 adjustedId = delegateId
             }
 
+            Self.logger.log(type: .info, message: "Setting StableID to \(adjustedId)")
+
             Self.shared._id = adjustedId
             self.setLocal(key: Constants.StableID_Key_Identifier, value: adjustedId)
             self.setRemote(key: Constants.StableID_Key_Identifier, value: adjustedId)
 
             self.delegate?.didChangeID(newID: adjustedId)
         }
+    }
+
+    private func generateID() {
+        Self.logger.log(type: .info, message: "Generating new StableID.")
+
+        let newID = self._idGenerator.generateID()
+        self.setIdentity(value: newID)
     }
 
     private func setLocal(key: String, value: String) {
@@ -134,8 +143,11 @@ extension StableID {
     public static var id: String { return Self.shared._id }
 
     public static func identify(id: String) {
-        logger.log(type: .info, message: "Setting StableID to \(id)")
         Self.shared.setIdentity(value: id)
+    }
+
+    public static func generateNewID() {
+        Self.shared.generateID()
     }
 
     public static func set(delegate: any StableIDDelegate) {

--- a/Tests/StableIDTests/StableIDTests.swift
+++ b/Tests/StableIDTests/StableIDTests.swift
@@ -11,9 +11,11 @@ final class StableIDTests: XCTestCase {
     }
 
     func clearDefaults() {
-        let defaults = UserDefaults.standard
+        guard let defaults = UserDefaults(suiteName: Constants.StableID_Key_DefaultsSuiteName) else { return }
+        
         let dictionary = defaults.dictionaryRepresentation()
         dictionary.keys.forEach { key in
+            print(key)
             defaults.removeObject(forKey: key)
         }
     }
@@ -36,4 +38,23 @@ final class StableIDTests: XCTestCase {
         XCTAssert(StableID.id == uuid)
     }
 
+    func testGenerateNewID() {
+        clearDefaults()
+        
+        StableID.configure()
+        let originalID = StableID.id
+
+        StableID.generateNewID()
+        let newID = StableID.id
+
+        XCTAssert(originalID != newID)
+    }
+
+    func testShortIDLength() {
+        clearDefaults()
+
+        StableID.configure(idGenerator: StableID.ShortIDGenerator())
+
+        XCTAssert(StableID.id.count == 8)
+    }
 }


### PR DESCRIPTION
## Background

It wasn't possible to re-use an IDGenerator's `generateID` method after configuring.

## Changes

### New features
- Adds `generateNewID` public method on `StableID` to create and identify an ID based on the configured `IDGenerator`
- Adds new `ShortIDGenerator`

### Bug fixes
- Fixed: Tests were using the wrong UserDefaults suite. 